### PR TITLE
Fix: Prevent PPO ratio corruption and KL divergence spikes in multi-role self-play

### DIFF
--- a/quarl/trainer/ppo/ssp_ray_trainer.py
+++ b/quarl/trainer/ppo/ssp_ray_trainer.py
@@ -656,6 +656,21 @@ class SSPRayPPOTrainer(RayPPOTrainer):
                             except Exception as e:
                                 logger.warning(f"Failed to dump proposer trajectories: {e}")
 
+                        if self.sp_config.proposer.enable and proposer_gen_batch is not None:
+                            proposer_gen_batch = self._capture_role_log_prob(
+                                proposer_gen_batch, "proposer", timing_raw
+                            )
+
+                        if (
+                            self.sp_config.solver.enable
+                            and solver_gen_batch is not None
+                            and (
+                                self.global_steps > self.sp_config.proposer.warm_up_steps
+                                or not self.sp_config.proposer.enable
+                            )
+                        ):
+                            solver_gen_batch = self._capture_role_log_prob(solver_gen_batch, "solver", timing_raw)
+
                         with marked_timer("model_updates", timing_raw):
 
                             representative_batch = solver_gen_batch
@@ -1464,6 +1479,7 @@ class SSPRayPPOTrainer(RayPPOTrainer):
             if key not in [
                 "old_log_probs",
                 "ref_log_prob",
+                "entropys",
                 "token_level_scores",
                 "token_level_rewards",
                 "advantages",
@@ -1473,14 +1489,30 @@ class SSPRayPPOTrainer(RayPPOTrainer):
                 gen_batch.batch[key] = gen_batch.batch[key].long()
 
         with marked_timer(f"{role}_old_log_prob", timing_raw, color="blue"):
-            old_log_prob = self.actor_rollout_wg.compute_log_prob(gen_batch)
-            entropys = old_log_prob.batch["entropys"]
+            if "old_log_probs" in gen_batch.batch.keys():
+                entropys = gen_batch.batch["entropys"]
+            else:
+                try:
+                    old_log_prob = self.actor_rollout_wg.compute_log_prob(gen_batch)
+                except Exception as e:
+                    if "numel() == 0" not in str(e) and "cu_seq_lens" not in str(e):
+                        raise
+                    logger.warning(
+                        f"{role}: compute_log_prob hit the empty-packed-sequence "
+                        f"error despite the response_mask/position_ids guard -- "
+                        f"skipping this role's update for step {self.global_steps} "
+                        f"rather than crashing the run: {e}"
+                    )
+                    return metrics
+                entropys = old_log_prob.batch["entropys"]
+                old_log_prob.batch.pop("entropys")
+                gen_batch = gen_batch.union(old_log_prob)
+
             response_masks = gen_batch.batch["response_mask"]
             loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
             entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
             metrics[f"{role}/actor/entropy"] = entropy_agg.detach().item()
-            old_log_prob.batch.pop("entropys")
-            gen_batch = gen_batch.union(old_log_prob)
+            gen_batch.batch.pop("entropys", None)
 
         if self.use_reference_policy:
             with marked_timer(f"{role}_ref", timing_raw, color="olive"):
@@ -1548,6 +1580,14 @@ class SSPRayPPOTrainer(RayPPOTrainer):
         )
 
         return metrics
+
+    def _capture_role_log_prob(self, gen_batch: DataProto, role: str, timing_raw: Dict) -> DataProto:
+        if gen_batch is None or "old_log_probs" in gen_batch.batch:
+            return gen_batch
+
+        with marked_timer(f"{role}_old_log_prob", timing_raw, color="blue"):
+            old_log_prob = self.actor_rollout_wg.compute_log_prob(gen_batch)
+            return gen_batch.union(old_log_prob)
 
     def _dump_trajectories(self, inputs, outputs, scores, role: str, step: int, reward_extra_infos_dict=None):
         try:


### PR DESCRIPTION
**The Problem:**
In the self-play training loop, multiple roles (e.g., proposer and solver) share a single policy and are updated sequentially within a single global step. Previously, `old_log_probs` were computed lazily during `_update_on_trajectories` right before each role's parameter update. 

Because the roles share weights, computing `old_log_probs` for the second role (Solver) meant evaluating them on a policy that had *already been updated* by the first role's (Proposer's) gradient step. 

**The Symptoms (KL Divergence Spikes):**
This execution order breaks PPO's importance sampling math ($r_t(\theta)$). The denominator in the PPO ratio evaluates the generated actions using updated weights ($W_1$) instead of the weights that actually generated the actions ($W_0$). This completely breaks the PPO clipping mechanism, causing the model to take erratic gradient steps to correct for "drift" that didn't actually happen. **This is the direct cause of massive KL divergence spikes** often seen during multi-role training, as the destabilized updates rapidly push the model away from the reference policy.

**The Solution:**
This PR updates `_update_on_trajectories` to check if `old_log_probs` (and `entropys`) already exist in the batch. 
* If they do, the update loop uses them directly. This allows the outer training loop to pre-capture `old_log_probs` immediately after generation for all roles (while the weights are still frozen at $W_0$) and pass them down safely.
* If they do not exist, it falls back to the legacy lazy computation to ensure backward compatibility for standard, single-role training loops.

**Secondary Fix (Empty Sequence Safety Net):**
Added a `try/except` fallback during the lazy `old_log_prob` computation to catch edge-case CUDA crashes caused by empty packed sequences (`numel() == 0` / `cu_seq_lens` errors). Rather than crashing the entire training job over a single malformed generation step (e.g., when a model immediately outputs an EOS token and the response mask filters out all tokens), it cleanly skips the role's update for that specific step and continues.